### PR TITLE
docs(skill): streamline daily jira steward workflow

### DIFF
--- a/.cursor/skills/daily-jira-steward/SKILL.md
+++ b/.cursor/skills/daily-jira-steward/SKILL.md
@@ -6,117 +6,149 @@ disable-model-invocation: true
 
 # Daily Jira Steward
 
-Use this skill as a morning routine to turn recent work into a saved daily work report and a separate draft set of Jira and GitHub PR updates.
+Use this skill as a daily checkpoint routine. Its normal job is to capture what happened between the last steward run and this steward run, update the owned visibility artifacts, then draft approval-gated updates for Jira, GitHub, and other trackers.
 
-## Rules
+## Non-Negotiables
 
-- Jira and GitHub PR writes are approval-gated. Draft proposed ticket creation, comments, field changes, transitions, and PR body/title updates first. Apply only the specific changes the user approves.
-- Use the answers UI for approval when it is available. Convert each proposed write into a selectable option so the user can choose exactly which Jira or GitHub changes to apply.
-- Never refer to a PR, Jira ticket, or GR ticket by number or key alone. Always include the readable title or summary next to it, such as `PR #123: Add status reconciliation` or `ROS-456: Track stale Jira review`.
-- Slack is required context for every run. Search it during the evidence pass and include Slack-specific work signals, decisions, coordination, blockers, support requests, and follow-ups in the daily report and `me.md` when relevant.
+- External writes are approval-gated. Draft Jira ticket creation, comments, field changes, transitions, PR body/title updates, and other tracker writes first. Apply only the specific changes the user approves.
+- Owned artifact writes do not need separate approval: the daily report repo, `me.md`, Google Doc sync, pending draft, and steward state.
+- Every `me.md` update must be followed by `python3 /Users/jgoon/github/daily-reports/scripts/sync-me-to-gdoc.py`. If sync fails, still commit the local `me.md` update and tell the user the Google Doc is stale.
+- The daily report is a comprehensive work log. Pending updates are only the subset of work that needs an external tracker or PR update.
+- Never refer to a PR, Jira ticket, or GR ticket by number or key alone. Include the readable title or summary, such as `PR #123: Add status reconciliation` or `ROS-456: Track stale Jira review`.
 - Do not create tickets for passing thoughts. Create tracking only when the user asks to track an idea or concrete evidence shows active work.
 - Prefer updating existing tickets over creating duplicates.
-- Triage the user's current Jira tickets every run. Look for stale status, missing progress comments, blockers, completed work, duplicate tracking, and tickets that should be linked to recent PRs or docs.
-- Treat `[n/a]` in a PR title as missing tracking, not as a reason to skip tracking, when the PR contains concrete work. Draft a Jira ticket plan and a PR update that links the approved ticket.
-- For related `[n/a]` PRs in the same workstream, prefer a parent ticket with useful immediate child tickets instead of unrelated standalone tickets. Reuse existing Jira tickets when they clearly cover the work.
-- Never close or transition a ticket from local commits alone. Require merged PR evidence, explicit user instruction, or a clearly completed Jira workflow signal.
-- Report repo writes are operational artifacts and do not need separate approval.
-- The `me.md` work visibility doc and Google Doc sync are operational artifacts and do not need separate approval.
-- The daily report and proposed Jira or PR updates have different jobs. The report is a comprehensive work log for later performance-cycle recall. Proposed updates are only the subset of work that needs Jira or GitHub tracking changes.
-- `me.md` is a short-lived visibility dashboard for other people, not a transcript. Refresh it from the evidence pass and triage; do not copy the full daily report into it.
+- Never close or transition a ticket from local commits alone. Require merged PR evidence, explicit user instruction, or a clear Jira workflow signal.
+- Cursor chats and Slack are mandatory evidence sources for every normal run. Always inspect both for the checkpoint window before synthesizing what happened.
+- Do not silently drop reviewed evidence. When a discovered chat, PR, Slack thread, Jira ticket, or stale item is intentionally left out of the work log, `me.md`, or proposed updates, record a short reason.
 
-## Daily Work Report Scope
+## Core Workflow
 
-The saved daily report should reflect everything the user did during the review window that has evidence in the inspected sources. Do not limit the report to work that needs Jira updates.
+### 1. Source the Evidence
 
-Capture concrete work signals such as implementation, debugging, CI or release work, code review, planning, design review, research, stakeholder coordination, support, incident or on-call work, docs, follow-ups, decisions made, and meaningful context gathering. Include small items when they help reconstruct the day later, but group tiny fragments under the same workstream instead of creating noisy one-off bullets.
+Establish the checkpoint review window. The normal window is from the last completed/reviewed steward checkpoint to this run's start. If the user does not specify a window, use `pending_since_at`, then `last_reviewed_through_at`, then the fallback lookback. Set `last_started_at` before the evidence pass so the run has a stable end.
 
-For each work item, include enough detail to be useful months later: the workstream or project, what changed or progressed, artifacts such as PRs, Jira tickets, docs, chats, or branches, relevant blockers or decisions, and the next step when one is visible. Prefer evidence-backed summaries over exhaustive transcript excerpts. Do not copy sensitive personal details or long private-message content into the report unless the user explicitly asks and it is necessary.
+Read any pending draft first and preserve its proposed-changes table and change IDs. Include pending items as prior context, but do not apply them until approved.
 
-Jira and PR tracking remains separate. A work item can appear in the daily report even when the right proposed update is `Skip`, no Jira change, or no PR change.
+Run the access gate for Jira/Atlassian, GitHub, Slack, the daily reports repo, and `gws`. If a required source fails because of auth, missing credentials, unavailable CLI/tooling, or permissions, stop and ask the user to repair access unless they explicitly approve a degraded run.
 
-## Access Gate
+Start with Cursor chats and Slack for the same checkpoint window.
 
-The steward is only effective when it can inspect the required systems. Before doing the full evidence pass, verify access to:
+Cursor chat commands:
 
-- Jira/Atlassian for current-ticket triage, stale-ticket searches, issue reads, and approved writes.
-- GitHub for PR activity, PR reads, and approved PR updates.
-- Slack for search, channel history, and thread reads during the review window.
-- The daily reports repo for pull, report write, `me.md` write, commit, and push.
-- Google Workspace (`gws`) for syncing `me.md` to the work visibility Google Doc.
+```bash
+python3 /Users/jgoon/.cursor/skills/daily-jira-steward/scripts/cursor-chat-search.py list --state-window
+python3 /Users/jgoon/.cursor/skills/daily-jira-steward/scripts/cursor-chat-search.py search --state-window "ROS-123"
+python3 /Users/jgoon/.cursor/skills/daily-jira-steward/scripts/cursor-chat-search.py show <chat-id>
+```
 
-If any required source or tool fails because of authentication, missing credentials, unavailable CLI/tooling, or missing permissions, stop and ask the user to authenticate or repair access. Do not continue with a degraded steward run unless the user explicitly approves a limited run after seeing which source is unavailable.
+`list --state-window` selects parent transcripts by file modification time from `pending_since_at` or `last_reviewed_through_at` through `last_started_at`. It includes chats updated during the window even if they were created earlier. Treat every listed parent chat prompt as a candidate work signal. Use `show <chat-id>` only for chats that need deeper reconstruction; do not dump all full chats.
 
-When stopping for access, report the exact source that failed, the command or tool category that failed, and the shortest next action for the user, such as refreshing `github.rbx.com` auth, completing Jira OAuth, running the host LCA helper, authenticating `gws`, or reopening in the devcontainer. Do not write a clean daily report, refresh `me.md`, sync the Google Doc, advance `last_completed_at`, advance `last_reviewed_through_at`, or mark pending items reviewed until the required source is available or the user explicitly accepts a degraded run.
+For Slack, first read `/Users/jgoon/.agents/skills/slack/SKILL.md` and follow its read-only workflow. Always run a broad outbound search for the current user across the checkpoint window before targeted Slack searches. Then search targeted terms from Cursor, GitHub, Jira, docs, branch names, PR titles, blocker words, and follow-up language. Expand only the highest-signal Slack threads or channel-history results.
 
-## Status Reconciliation
+Search GitHub, Slack, Jira, local branches/commits, docs, Confluence, Google Drive, Gmail, calendar, production signals, or other relevant systems when they identify work, blockers, decisions, or completion evidence.
 
-Every run should compare Jira status against the strongest available evidence and draft transitions when they are out of date.
+### 2. Determine What Happened and Publish Owned Artifacts
 
-Use these defaults unless a team workflow or user instruction says otherwise:
+Synthesize one comprehensive work log from the evidence before deciding what needs external updates. Capture implementation, debugging, CI or release work, code review, planning, design review, research, stakeholder coordination, support, incident or on-call work, docs, decisions, follow-ups, blockers, and meaningful context gathering.
+
+For each work item, include enough detail to be useful months later: workstream, what changed or progressed, artifacts, relevant blockers or decisions, and the visible next step. Group tiny fragments under the same workstream instead of creating noisy one-off bullets.
+
+Keep an `Intentional Omissions / No Action` list for reviewed evidence that was excluded from the work log, `me.md`, or proposed updates. Reasons can be duplicate, low signal, personal/no work signal, already tracked, no action needed, or outside the review window.
+
+Refresh `/Users/jgoon/github/daily-reports/me.md` from the synthesized work log. `me.md` is a short-lived visibility dashboard for other people, not a transcript. It should show current focus, status, blockers, next steps, and useful shareable links. Always run the Google Doc sync script after changing `me.md`.
+
+Write or append the daily report at `/Users/jgoon/github/daily-reports/reports/YYYY-MM-DD.md` using the review-window end date in local time. Commit and push the report repo changes, then sync `me.md` to Google Docs:
+
+```bash
+git -C /Users/jgoon/github/daily-reports pull --ff-only
+git -C /Users/jgoon/github/daily-reports add reports/YYYY-MM-DD.md me.md
+git -C /Users/jgoon/github/daily-reports commit -m "docs: add daily report for YYYY-MM-DD"
+git -C /Users/jgoon/github/daily-reports push
+python3 /Users/jgoon/github/daily-reports/scripts/sync-me-to-gdoc.py
+```
+
+When only `me.md` changes, commit with `docs: refresh work visibility for YYYY-MM-DD` and still run the Google Doc sync script.
+
+### 3. Draft Pending External Updates
+
+From the synthesized work log, draft exact pending updates for Jira, GitHub, and any other trackers. Draft creates, comments, status transitions, field changes, PR body/title updates, PR comments, and explicit skips.
+
+Triage current assigned/reported Jira tickets every run. Look for stale status, missing progress comments, blockers, completed work, duplicate tracking, and tickets that should be linked to recent PRs or docs.
+
+Treat `[n/a]` in a PR title as missing tracking when the PR contains concrete work. Draft a Jira ticket plan and a PR update that links the approved ticket. For related `[n/a]` PRs in the same workstream, prefer a parent ticket with useful immediate child tickets instead of unrelated standalone tickets.
+
+Use these default Jira status recommendations unless a team workflow or user instruction says otherwise:
 
 - Concrete work found but no PR yet: move the tracking ticket to `In Progress`.
 - PR is open for the ticket: move the ticket to `In Review`.
-- PR is merged and the ticket still needs rollout, observation, or follow-up validation: move the ticket to `In Testing`.
-- PR is merged and the ticket's acceptance criteria are complete with no known follow-up: move the ticket to `Closed`.
-- Parent workstream with any active child tickets: keep the parent at `In Progress`.
-- Parent workstream with only review-state child tickets: use `In Review` if the parent is mainly waiting on review.
-- Parent workstream with all child tickets closed or verified: draft closing the parent.
+- PR is merged and still needs rollout, observation, or validation: move the ticket to `In Testing`.
+- PR is merged and acceptance criteria are complete with no known follow-up: move the ticket to `Closed`.
+- Parent workstream with active child tickets: keep the parent at `In Progress`.
 
-Draft status transitions with the evidence that supports them. Jira transitions are still approval-gated unless the user explicitly asks to apply them.
-
-## Stale Ticket Callouts
-
-Every run should include a small stale-ticket review so old work does not disappear. Treat staleness as a reminder signal, not proof that Jira needs a write.
-
-Default searches:
+Run stale-ticket searches every run:
 
 ```text
 project in (ROS, ROSHELP) AND assignee = currentUser() AND statusCategory != Done AND updated <= -14d ORDER BY updated ASC
 project in (ROS, ROSHELP) AND reporter = currentUser() AND statusCategory != Done AND updated <= -30d ORDER BY updated ASC
 ```
 
-Use these thresholds unless the ticket, team workflow, or user instruction suggests a better bar:
+Stale tickets are reminder signals, not automatic writes. Include stale callouts in the report, but draft comments or transitions only when evidence supports action.
 
-- In Review with no update for 7+ days: call out as likely waiting on review, merge, or a status correction.
-- In Testing with no update for 14+ days: call out as likely needing validation, rollout notes, or closure.
-- In Progress with no update for 21+ days: call out as possibly blocked, forgotten, or missing a progress comment.
-- To Do, Backlog, or unstarted work with no update for 30+ days: call out as stale if it still appears relevant; otherwise suggest closing, deprioritizing, or leaving alone with a reason.
-- Any active assigned ticket with no update for 60+ days: always include it as long-stale, even if no action is obvious.
+Save the pending draft to `~/.cursor/skills/daily-jira-steward/pending-draft.md` with the proposed-changes table before detailed notes.
 
-For each stale callout, include the age, current status, owner/relationship to the user, why it might matter, and the lightest useful next step. Prefer `needs a quick look`, `candidate to close`, `waiting on external signal`, `probably still fine`, or `needs user judgment` over inventing urgency. Do not draft Jira comments solely because a ticket is old; draft a comment, transition, or close action only when there is supporting evidence or the user asks to clean it up.
+### 4. Approval Gate and Apply Approved Writes
 
-## Sources
+Present the daily report summary, `me.md`/Google Doc status, and pending proposed changes. Use the answers UI when available, with one selectable option per proposed write. Add `Apply all proposed changes` only when every row is low-risk and fully evidenced. Add `Skip all for now` when there are pending writes.
 
-Use whatever relevant sources are available to reconstruct the review window: Cursor chat transcripts, current chat context, git branches, commits, GitHub PRs, Jira, Slack, Gmail, calendar, docs, Confluence, Google Drive, production signals, or other systems that identify work, blockers, decisions, completion evidence, or day-to-day effort.
+Apply only rows the user explicitly approves. Keep unapproved rows pending. Do not show rejected rows again unless new evidence appears or the user asks to revisit them.
 
-For Cursor chats, include transcripts updated during the review window, even if the chat was created earlier. Use transcript file modification time to select candidate chats. When message timestamps are available, summarize only messages or events inside the review window. If timestamps are unclear, include the transcript and summarize only concrete work signals that appear relevant. Include work even when it did not produce a PR, Jira change, or final shipped artifact.
+After a clean run, set `last_completed_at`, set `last_reviewed_through_at` to the review-window end, and record `last_report_path`. If proposed Jira/GitHub changes remain unapproved, keep `pending_since_at` and `pending_draft_path` set so the next run includes them.
 
-For Jira in the ROS workspace, first read `.cursor/skills/ros-atlassian/SKILL.md` and follow its routing. Outside ROS, use the available Jira or Atlassian skill. For GitHub, prefer the `gh` CLI when available.
+## Subagents
 
-For Slack, first read `/Users/jgoon/.agents/skills/slack/SKILL.md` and follow its read-only workflow. Always run a Slack pass for the review window. Start with the same time window chosen from steward state, usually `last_reviewed_through_at` or `pending_since_at` through `last_started_at`.
+The parent agent owns the review window, state file, access gate, synthesis, report-repo writes, Google Doc sync, pending draft, answers UI, and approved external writes.
 
-Run the Slack pass in this order:
+Use read-only subagents after the access gate when available. Give every subagent the exact review-window start and end, the citation rules, and a clear instruction to return concise evidence. Subagents must not mutate Jira, GitHub, Google Docs, the daily reports repo, or the steward state.
 
-1. Broad outbound search for the current user, such as `from:<user> after:YYYY-MM-DD before:YYYY-MM-DD`. This is required before targeted searches because it catches coordination that GitHub, Jira, and transcripts will not name with stable keys.
-2. Targeted searches from evidence already found in GitHub, Jira, Cursor chats, and local branches. Use Jira keys, PR numbers, PR titles, branch names, repo names, product/workstream terms, docs, stakeholder names when known, and likely support or coordination phrases.
-3. Search for likely follow-up or blocker language when the work log suggests coordination, for example `blocking`, `rerun`, `review`, `approved`, `apply`, `sync`, `incident`, or `handoff` with the workstream term.
+Recommended split:
 
-Treat Slack as work-signal evidence, not as transcript material. Capture decisions, requests, coordination, blockers, rollout notes, support triage, follow-ups, and stakeholder confirmations. Ignore standalone acknowledgements such as `thanks`, `no problem`, or emoji-only messages unless they anchor a thread with useful context.
+- Cursor chat evidence: run `cursor-chat-search.py list --state-window`, inspect every prompt, selectively `search` and `show <chat-id>`, then return workstreams, artifacts, decisions, blockers, follow-ups, and chat IDs.
+- GitHub evidence: list PRs, commits, branches, reviews, and materially updated PRs during the window across relevant repos. Call out `[n/a]` gaps, merged PRs that may close tickets, and open PRs that imply status changes.
+- Slack evidence: search outbound activity first across the checkpoint window, then targeted terms from Cursor/GitHub/Jira. Return high-signal coordination, decisions, support asks, blockers, important misses, and only the highest-signal expanded threads.
+- Jira triage evidence: read current assigned/reported tickets, tickets linked from evidence, and stale-ticket searches. Return status mismatches, likely duplicates, needed comments, no-action tickets, and stale callouts.
 
-Expand only the 2-5 highest-signal threads or channel-history results. Prefer threads that include decisions, blockers, asks, approvals, incident/support context, or links to PRs, Jira, TFE, dashboards, or docs. Do not expand every result; it creates noise and increases rate-limit risk.
+Ask each subagent to return:
 
-If a Slack `thread` or `history` command hits rate limits, fails repeatedly, or appears stuck, stop after one failed expansion attempt for that item. Record the search result snippet, channel/thread link, and that expansion was skipped due to rate limiting. Continue the steward run with the remaining evidence instead of blocking.
+```markdown
+## Source Checked
+[tooling, queries, window]
 
-Record both useful Slack hits and important Slack misses. For example, note that broad user search found ArgoCD and IAM coordination, while targeted searches for a Jira key or WAF term returned no matches. Slack misses are useful because they show the steward looked for coordination and found none.
+## Work Signals
+- [workstream]: [what happened, evidence, artifact links or local chat IDs, next step/blocker]
 
-Cite Slack by channel or thread context and timestamp when useful, but summarize instead of copying long messages or private details. Expand outside the window only when needed for context, such as reading a thread that started earlier or following a referenced decision.
+## Tracking Implications
+- [Jira/PR candidate update, skip reason, or stale callout]
 
-Prefer direct evidence over inference. Do not copy long chat excerpts or sensitive details into Jira unless they are necessary for tracking the work.
+## Intentional Omissions
+- [reviewed evidence intentionally left out and why]
 
-## State and Reports
+## Important Misses or Blockers
+- [searches that found nothing useful, auth/rate-limit gaps, uncertainty]
+```
 
-Store skill state in `~/.cursor/skills/daily-jira-steward/state.json`:
+If sources disagree, prefer direct artifact evidence and note uncertainty in the report or Questions section instead of inventing a conclusion.
+
+## Source Notes
+
+For Jira in the ROS workspace, first read `.cursor/skills/ros-atlassian/SKILL.md` and follow its routing. Outside ROS, use the available Jira or Atlassian skill. For GitHub, prefer `gh`.
+
+For Slack, first read `/Users/jgoon/.agents/skills/slack/SKILL.md` and follow its read-only workflow. Always run a Slack pass for the checkpoint window between the previous reviewed point and this run's `last_started_at`. Treat Slack as work-signal evidence, not transcript material. Capture decisions, requests, coordination, blockers, rollout notes, support triage, follow-ups, and stakeholder confirmations. Ignore standalone acknowledgements such as `thanks`, `no problem`, or emoji-only messages unless they anchor useful context.
+
+Expand only the highest-signal Slack threads or channel-history results. If a Slack `thread` or `history` command hits rate limits, fails repeatedly, or appears stuck, stop after one failed expansion attempt for that item. Record the snippet, channel/thread link, and that expansion was skipped.
+
+Prefer direct evidence over inference. Do not copy long chat excerpts or sensitive details into Jira unless necessary for tracking the work.
+
+## State
 
 ```json
 {
@@ -129,190 +161,14 @@ Store skill state in `~/.cursor/skills/daily-jira-steward/state.json`:
 }
 ```
 
-At run start, set `last_started_at` to the current time. If the user does not specify a window, choose the start time from `pending_since_at`, then `last_reviewed_through_at`, then the last 24 hours on weekdays or 72 hours after a weekend. Use `last_started_at` as the review-window end so work that happens during the run is picked up next time.
+State file: `~/.cursor/skills/daily-jira-steward/state.json`.
 
-Save the draft to `~/.cursor/skills/daily-jira-steward/pending-draft.md`. If proposed Jira or GitHub changes are not applied, keep `pending_since_at` and `pending_draft_path` set so the next run includes them. Clear both only after updates are applied, the user says to mark them reviewed, or there are no proposed Jira or GitHub changes.
+Pending draft: `~/.cursor/skills/daily-jira-steward/pending-draft.md`.
 
-After a clean run, set `last_completed_at`, set `last_reviewed_through_at` to the review-window end, and record `last_report_path`.
+Daily reports repo: `/Users/jgoon/github/daily-reports`.
 
-Persist daily reports in `github.rbx.com/jgoon/daily-reports` using the local checkout at `/Users/jgoon/github/daily-reports`. If missing, clone `https://github.rbx.com/jgoon/daily-reports.git`. Pull with `--ff-only` before writing.
+`me.md` Google Doc mirror: `https://docs.google.com/document/d/1YB1z9XYfCdxXiVbDSy_Fl8DorysXuZzqtbVn8nHx1vA/edit`.
 
-Write reports to `reports/YYYY-MM-DD.md` using the review-window end date in local time. Append a new run section if the file already exists.
+## Artifact Templates
 
-## Work Visibility Doc (`me.md`)
-
-Maintain `/Users/jgoon/github/daily-reports/me.md` as the stable index for active work. Google Doc mirror: `https://docs.google.com/document/d/1YB1z9XYfCdxXiVbDSy_Fl8DorysXuZzqtbVn8nHx1vA/edit`
-
-After the evidence pass and before presenting approvals, refresh `me.md` from the same sources used for the daily report. Set `Last updated: YYYY-MM-DD` to the review-window end date in local time.
-
-Write `me.md` for readers who may not have the user's local context, chat history, branch names, or shorthand. Each item should name the workstream, explain why it matters, state the current status, and make the next step or blocker understandable without requiring the daily report.
-
-Because `me.md` is synced to Google Docs, every link in it must work for someone reading the Google Doc. Never put local filesystem paths, `file://` URLs, `localhost` URLs, or machine-specific links in `me.md`. For files or reports that are pushed to GitHub, use their remote GitHub URL. If an artifact only exists locally, describe it without linking until it has a shareable remote URL.
-
-Keep this structure:
-
-```markdown
-# Josh Goon Work Visibility
-
-Last updated: YYYY-MM-DD
-
-## Now
-- **Focus:** ...
-- **Goal:** ...
-- **Status:** ...
-- **Needs attention:** ...
-- **Links:** [latest daily report](https://github.rbx.com/jgoon/daily-reports/blob/main/reports/YYYY-MM-DD.md), ...
-
-## Next
-- [concrete next actions with PR/Jira links]
-
-## Backlog
-- [lower-priority or stale follow-ups with links]
-
-## Done Recently
-- [3-6 bullets for work completed or materially advanced in the last ~2 weeks; drop items older than that]
-
-## Useful Links
-- Daily reports: [YYYY-MM-DD](https://github.rbx.com/jgoon/daily-reports/blob/main/reports/YYYY-MM-DD.md), ...
-- Jira: [active ROS work](...)
-- GitHub: [ROS PRs by Josh](...), [ros-infra PRs by Josh](...)
-- Docs: ...
-```
-
-Guidelines:
-
-- **Now** reflects current focus, goal, status, blockers, and 3-5 high-signal links (latest report, top active Jira, top open PRs).
-- **Next** is ordered, actionable, and uses the readable `PR #N: title` / `ROS-N: title` style.
-- **Backlog** holds tickets or themes not actively being worked this week.
-- **Done Recently** rotates forward; remove bullets that are no longer useful for standups or manager visibility.
-- Prefer markdown links over bare URLs. Use full remote URLs, not relative paths, because Google Docs readers need links that work outside the local checkout.
-- Do not include approval-gated Jira or GitHub writes that are still `Pending` unless they are already part of the user's committed plan.
-
-Sync to Google Docs after saving `me.md` (uses Drive native Markdown import, then a date chip on `Last updated`):
-
-```bash
-python3 /Users/jgoon/github/daily-reports/scripts/sync-me-to-gdoc.py
-```
-
-If `gws` or the sync script fails, still commit `me.md` when the report is committed, and tell the user the Google Doc is stale until sync succeeds.
-
-Commit and push report-repo changes after writing the report and refreshing `me.md`:
-
-```bash
-git -C /Users/jgoon/github/daily-reports pull --ff-only
-git -C /Users/jgoon/github/daily-reports add reports/YYYY-MM-DD.md me.md
-git -C /Users/jgoon/github/daily-reports commit -m "docs: add daily report for YYYY-MM-DD"
-git -C /Users/jgoon/github/daily-reports push
-python3 /Users/jgoon/github/daily-reports/scripts/sync-me-to-gdoc.py
-```
-
-When only `me.md` changes on a run (no new report file), commit with `docs: refresh work visibility for YYYY-MM-DD` and run the sync script.
-
-## Workflow
-
-1. Establish the review window from checkpoint tracking unless the user specifies a window.
-2. Read any pending draft first and show it as Pending Approval, preserving its proposed-changes table and change IDs.
-3. Run the access gate for Jira/Atlassian, GitHub, Slack, the daily reports repo, and `gws`. Stop and ask for auth if any required source is unavailable.
-4. Inspect relevant sources, including Cursor chats and Slack activity updated during the window. For Slack, run the broad outbound search before targeted searches, then expand only high-signal threads.
-5. Build a comprehensive work log from the evidence before deciding which items need Jira or PR updates.
-6. Triage the user's current Jira tickets and compare them against recent evidence.
-7. Run the stale-ticket review and call out long-stale tickets separately from evidence-backed proposed updates.
-8. List GitHub activity in the report, including PRs created, merged, reviewed, or materially updated during the window. Include `[n/a]` PRs explicitly.
-9. Draft exact Jira and GitHub PR updates: creates, comments, transitions, PR link updates, and skips. For related work, draft one parent ticket and only useful immediate child tickets.
-10. Save the pending draft, write the daily report, refresh `me.md`, commit and push the report repo, then run `scripts/sync-me-to-gdoc.py`.
-11. Present the report, note the `me.md` and Google Doc refresh, and use the answers UI, when available, to ask which proposed changes to apply.
-12. If the user approves all or part of the draft, apply only the selected rows from the proposed-changes table. Keep unapproved items pending. Do not show rejected items again unless new evidence appears or the user asks to revisit them.
-
-## Approval Answers UI
-
-When there are proposed Jira or GitHub writes, use the answers UI before applying them. Offer one selectable option per proposed change, keyed by the table's change ID. Add `Apply all proposed changes` only when every row is low-risk and fully evidenced. Add `Skip all for now` when there are pending writes.
-
-Each option label must include the action, the target identifier, and the target title or summary from the `Write` column. Do not use labels like `ROS-123` or `PR #456` by themselves.
-
-If the answers UI is not available, ask for approval in chat using the same change IDs. Apply only rows the user explicitly approves.
-
-## Pending Draft Format
-
-Every pending draft must include a proposed-changes table before any detailed notes. Keep one row per write action so it can be converted directly into answers UI options.
-
-Keep the table readable in narrow editors. Use only these four columns:
-
-- `Change ID`: stable identifier such as `JIRA-1` or `GH-1`.
-- `Write`: combine system, action, target, and readable title or summary. Include the target key or PR number when one exists.
-- `Details`: combine the proposed change and the evidence. Keep it specific enough to apply the write without rereading the whole report.
-- `Status`: `Pending`, `Approved`, `Applied`, `Skipped`, or `Rejected`, with a short reason when helpful.
-
-```markdown
-| Change ID | Write | Details | Status |
-| --------- | ----- | ------- | ------ |
-| JIRA-1 | Jira transition for `ROS-123: Add status reconciliation` | Move from `In Progress` to `In Review`. Evidence: `PR #456: Add reconciliation` is open. | Pending |
-| GH-1 | GitHub PR update for `PR #456: Add reconciliation` | Replace `[n/a]` with `ROS-123: Add status reconciliation`. Evidence: PR implements tracked Jira work. | Pending |
-```
-
-For new ticket creation, start the `Write` cell with `Jira create: [ticket summary]`. For existing tickets and PRs, include both the target identifier and readable title in the `Write` cell.
-
-## Daily Report Format
-
-Use this structure when reporting back and when writing the daily report file:
-
-```markdown
-## Daily Work Report
-
-Window: [start time] to [end time]
-Report saved at: [repo path]
-
-## Sources Checked
-
-- [source and scope]
-
-## Work Log
-
-- [workstream or project]: [what the user did, evidence or artifacts, outcome or progress, blockers or next step if visible]
-
-## Slack Evidence
-
-- Broad search: [time window, query shape, high-signal hits, and important misses]
-- Targeted search: [Jira keys, PRs, workstream terms searched, high-signal hits, and important misses]
-- Threads expanded: [channel/thread context, what decision/blocker/coordination was found, or rate-limit skip]
-
-## Artifact Summary
-
-- PR: [PR number and title, created/merged/reviewed/materially updated, why it mattered]
-- Jira: [ticket key and title, work performed or status observed]
-- Doc/Chat/Other: [artifact title or source, work performed or decision made]
-
-## Pending Approval
-
-| Change ID                 | Write                                            | Details                                          | Status                                             |
-| ------------------------- | ------------------------------------------------ | ------------------------------------------------ | -------------------------------------------------- |
-| [prior pending change ID] | [system, action, target, and readable title]     | [specific proposed write plus supporting evidence] | [Pending, Approved, Applied, Skipped, or Rejected] |
-
-## GitHub Activity
-
-- [PR created, merged, reviewed, or materially updated, always including PR number and title]
-
-## Current Jira Triage
-
-- [ticket key and title, observed state, proposed action or reason no action is needed]
-
-## Stale Ticket Callouts
-
-- [ticket key and title, age since last update, status, why it may need attention, lightest useful next step]
-
-## Proposed Jira Updates
-
-- Create: [ticket summary and reason]
-- Update: [ticket key and title, comment or field change, reason]
-- Transition: [ticket key and title, from state to state, evidence]
-- Skip: [work item, reason no Jira change is needed]
-
-## Proposed GitHub PR Updates
-
-- Update: [PR number and title, body/title/comment change, reason]
-
-## Questions
-
-- [Only include blockers that require user judgment]
-```
-
-If there is no Jira or PR tracking change to make, still write the full daily work report and say Jira and GitHub tracking already appear aligned.
+When writing or refreshing `me.md`, the daily report, or the pending draft, read `templates.md` in this skill directory and follow the relevant template. Keep the main workflow in this file as the source of truth for when each artifact is written.

--- a/.cursor/skills/daily-jira-steward/SKILL.md
+++ b/.cursor/skills/daily-jira-steward/SKILL.md
@@ -31,6 +31,8 @@ Read any pending draft first and preserve its proposed-changes table and change 
 
 Run the access gate for Jira/Atlassian, GitHub, Slack, the daily reports repo, and `gws`. If a required source fails because of auth, missing credentials, unavailable CLI/tooling, or permissions, stop and ask the user to repair access unless they explicitly approve a degraded run.
 
+When stopping for access, name the failed source, the failed command or tool category, and the shortest next action. Do not write a clean report, refresh `me.md`, sync the Google Doc, advance `last_completed_at`, advance `last_reviewed_through_at`, or mark pending items reviewed until access is repaired or the user explicitly approves a degraded run.
+
 Start with Cursor chats and Slack for the same checkpoint window.
 
 Cursor chat commands:
@@ -42,6 +44,8 @@ python3 /Users/jgoon/.cursor/skills/daily-jira-steward/scripts/cursor-chat-searc
 ```
 
 `list --state-window` selects parent transcripts by file modification time from `pending_since_at` or `last_reviewed_through_at` through `last_started_at`. It includes chats updated during the window even if they were created earlier. Treat every listed parent chat prompt as a candidate work signal. Use `show <chat-id>` only for chats that need deeper reconstruction; do not dump all full chats.
+
+When transcript message timestamps are available, summarize only messages or events inside the review window. If timestamps are unclear, include the chat as candidate evidence and summarize only concrete work signals that appear relevant.
 
 For Slack, first read `/Users/jgoon/.agents/skills/slack/SKILL.md` and follow its read-only workflow. Always run a broad outbound search for the current user across the checkpoint window before targeted Slack searches. Then search targeted terms from Cursor, GitHub, Jira, docs, branch names, PR titles, blocker words, and follow-up language. Expand only the highest-signal Slack threads or channel-history results.
 
@@ -69,13 +73,15 @@ python3 /Users/jgoon/github/daily-reports/scripts/sync-me-to-gdoc.py
 
 When only `me.md` changes, commit with `docs: refresh work visibility for YYYY-MM-DD` and still run the Google Doc sync script.
 
+If `/Users/jgoon/github/daily-reports` is missing, clone `https://github.rbx.com/jgoon/daily-reports.git` before writing. Do not put approval-gated pending Jira/GitHub writes into `me.md` unless they are already part of the user's committed plan.
+
 ### 3. Draft Pending External Updates
 
 From the synthesized work log, draft exact pending updates for Jira, GitHub, and any other trackers. Draft creates, comments, status transitions, field changes, PR body/title updates, PR comments, and explicit skips.
 
 Triage current assigned/reported Jira tickets every run. Look for stale status, missing progress comments, blockers, completed work, duplicate tracking, and tickets that should be linked to recent PRs or docs.
 
-Treat `[n/a]` in a PR title as missing tracking when the PR contains concrete work. Draft a Jira ticket plan and a PR update that links the approved ticket. For related `[n/a]` PRs in the same workstream, prefer a parent ticket with useful immediate child tickets instead of unrelated standalone tickets.
+Treat `[n/a]` in a PR title as missing tracking when the PR contains concrete work. Draft a Jira ticket plan and a PR update that links the approved ticket. For related `[n/a]` PRs in the same workstream, prefer a parent ticket with useful immediate child tickets instead of unrelated standalone tickets. Reuse existing Jira tickets when they clearly cover the work.
 
 Use these default Jira status recommendations unless a team workflow or user instruction says otherwise:
 
@@ -84,6 +90,8 @@ Use these default Jira status recommendations unless a team workflow or user ins
 - PR is merged and still needs rollout, observation, or validation: move the ticket to `In Testing`.
 - PR is merged and acceptance criteria are complete with no known follow-up: move the ticket to `Closed`.
 - Parent workstream with active child tickets: keep the parent at `In Progress`.
+- Parent workstream with only review-state child tickets: use `In Review` if the parent is mainly waiting on review.
+- Parent workstream with all child tickets closed or verified: draft closing the parent.
 
 Run stale-ticket searches every run:
 
@@ -94,15 +102,19 @@ project in (ROS, ROSHELP) AND reporter = currentUser() AND statusCategory != Don
 
 Stale tickets are reminder signals, not automatic writes. Include stale callouts in the report, but draft comments or transitions only when evidence supports action.
 
+Use these stale-ticket thresholds unless the ticket, team workflow, or user instruction suggests a better bar: In Review 7+ days, In Testing 14+ days, In Progress 21+ days, To Do/Backlog/unstarted 30+ days, and any active assigned ticket 60+ days. For each stale callout, include age, current status, relationship to the user, why it may matter, and the lightest useful next step. Prefer `needs a quick look`, `candidate to close`, `waiting on external signal`, `probably still fine`, or `needs user judgment` over inventing urgency.
+
 Save the pending draft to `~/.cursor/skills/daily-jira-steward/pending-draft.md` with the proposed-changes table before detailed notes.
 
 ### 4. Approval Gate and Apply Approved Writes
 
-Present the daily report summary, `me.md`/Google Doc status, and pending proposed changes. Use the answers UI when available, with one selectable option per proposed write. Add `Apply all proposed changes` only when every row is low-risk and fully evidenced. Add `Skip all for now` when there are pending writes.
+Present the daily report summary, `me.md`/Google Doc status, and pending proposed changes. Use the answers UI when available, with one selectable option per proposed write. Each option label must include the action, target identifier, and target title or summary. Add `Apply all proposed changes` only when every row is low-risk and fully evidenced. Add `Skip all for now` when there are pending writes.
 
 Apply only rows the user explicitly approves. Keep unapproved rows pending. Do not show rejected rows again unless new evidence appears or the user asks to revisit them.
 
 After a clean run, set `last_completed_at`, set `last_reviewed_through_at` to the review-window end, and record `last_report_path`. If proposed Jira/GitHub changes remain unapproved, keep `pending_since_at` and `pending_draft_path` set so the next run includes them.
+
+Clear `pending_since_at` and `pending_draft_path` only after updates are applied, the user says to mark them reviewed, or there are no proposed external changes.
 
 ## Subagents
 
@@ -145,6 +157,8 @@ For Jira in the ROS workspace, first read `.cursor/skills/ros-atlassian/SKILL.md
 For Slack, first read `/Users/jgoon/.agents/skills/slack/SKILL.md` and follow its read-only workflow. Always run a Slack pass for the checkpoint window between the previous reviewed point and this run's `last_started_at`. Treat Slack as work-signal evidence, not transcript material. Capture decisions, requests, coordination, blockers, rollout notes, support triage, follow-ups, and stakeholder confirmations. Ignore standalone acknowledgements such as `thanks`, `no problem`, or emoji-only messages unless they anchor useful context.
 
 Expand only the highest-signal Slack threads or channel-history results. If a Slack `thread` or `history` command hits rate limits, fails repeatedly, or appears stuck, stop after one failed expansion attempt for that item. Record the snippet, channel/thread link, and that expansion was skipped.
+
+Record both useful Slack hits and important Slack misses. Expand outside the window only when needed for context, such as reading a thread that started earlier or following a referenced decision.
 
 Prefer direct evidence over inference. Do not copy long chat excerpts or sensitive details into Jira unless necessary for tracking the work.
 

--- a/.cursor/skills/daily-jira-steward/scripts/cursor-chat-search.py
+++ b/.cursor/skills/daily-jira-steward/scripts/cursor-chat-search.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""List, search, and render Cursor agent transcripts for daily steward runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+
+DEFAULT_PROJECT_ROOT = Path("/Users/jgoon/github/ros")
+DEFAULT_STATE_FILE = Path("/Users/jgoon/.cursor/skills/daily-jira-steward/state.json")
+LOCAL_TZ = datetime.now().astimezone().tzinfo
+
+
+@dataclass(frozen=True)
+class TimeWindow:
+    start: datetime | None
+    end: datetime | None
+    label: str
+
+
+@dataclass(frozen=True)
+class Chat:
+    id: str
+    path: Path
+    mtime: datetime
+    line_count: int
+    title: str
+    prompt: str
+    citation: str
+    is_subagent: bool
+
+
+@dataclass(frozen=True)
+class ChatEvent:
+    role: str
+    text: str
+
+
+def parse_local_datetime(value: str) -> datetime:
+    normalized = value.strip()
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", normalized):
+        return datetime.combine(date.fromisoformat(normalized), time.min, tzinfo=LOCAL_TZ)
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=LOCAL_TZ)
+    return parsed.astimezone(LOCAL_TZ)
+
+
+def build_window(args: argparse.Namespace) -> TimeWindow:
+    window_args = [
+        bool(getattr(args, "state_window", False)),
+        bool(args.date),
+        bool(args.since),
+        bool(args.start or args.end),
+    ]
+    if sum(window_args) > 1:
+        raise SystemExit("Use only one window selector: --state-window, --date, --since, or --start/--end.")
+
+    if getattr(args, "state_window", False):
+        return build_state_window(Path(args.state_file).expanduser().resolve())
+
+    if args.since:
+        start = parse_local_datetime(args.since)
+        return TimeWindow(start=start, end=None, label=f"since {start.isoformat()}")
+
+    if args.date:
+        start = datetime.combine(date.fromisoformat(args.date), time.min, tzinfo=LOCAL_TZ)
+        return TimeWindow(start=start, end=start + timedelta(days=1), label=args.date)
+
+    start = parse_local_datetime(args.start) if args.start else None
+    end = parse_local_datetime(args.end) if args.end else None
+    if start and end:
+        label = f"{start.isoformat()} to {end.isoformat()}"
+    elif start:
+        label = f"after {start.isoformat()}"
+    elif end:
+        label = f"before {end.isoformat()}"
+    else:
+        label = "all time"
+    return TimeWindow(start=start, end=end, label=label)
+
+
+def build_state_window(state_file: Path) -> TimeWindow:
+    if not state_file.exists():
+        raise SystemExit(f"State file does not exist: {state_file}")
+    with state_file.open("r", encoding="utf-8") as handle:
+        state = json.load(handle)
+
+    start_value = state.get("pending_since_at") or state.get("last_reviewed_through_at")
+    end_value = state.get("last_started_at")
+    if not start_value:
+        raise SystemExit(f"State file has no pending_since_at or last_reviewed_through_at: {state_file}")
+
+    start = parse_local_datetime(start_value)
+    parsed_end = parse_local_datetime(end_value) if end_value else None
+    end = parsed_end if parsed_end and parsed_end > start else datetime.now(tz=LOCAL_TZ)
+    if end <= start:
+        raise SystemExit(f"State window end must be after start: {start.isoformat()} to {end.isoformat()}")
+    return TimeWindow(start=start, end=end, label=f"state window {start.isoformat()} to {end.isoformat()}")
+
+
+def project_key(project_root: Path) -> str:
+    return str(project_root.expanduser().resolve()).lstrip(os.sep).replace(os.sep, "-")
+
+
+def transcript_root(args: argparse.Namespace) -> Path:
+    if args.transcripts_root:
+        return Path(args.transcripts_root).expanduser().resolve()
+    project_root = Path(args.project_root).expanduser().resolve()
+    return Path.home() / ".cursor" / "projects" / project_key(project_root) / "agent-transcripts"
+
+
+def iter_transcript_paths(root: Path, include_subagents: bool) -> Iterable[Path]:
+    if not root.exists():
+        raise SystemExit(f"Transcript root does not exist: {root}")
+    for path in root.glob("**/*.jsonl"):
+        if not include_subagents and "subagents" in path.parts:
+            continue
+        yield path
+
+
+def in_window(path: Path, window: TimeWindow) -> bool:
+    mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=LOCAL_TZ)
+    if window.start and mtime < window.start:
+        return False
+    if window.end and mtime >= window.end:
+        return False
+    return True
+
+
+def content_text(value: Any, *, include_tool_json: bool) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "\n".join(part for item in value if (part := content_text(item, include_tool_json=include_tool_json)))
+    if not isinstance(value, dict):
+        return str(value)
+
+    item_type = value.get("type")
+    if item_type == "text":
+        return str(value.get("text", ""))
+    if item_type == "tool_use":
+        name = value.get("name", "tool")
+        if not include_tool_json:
+            return f"[tool_use {name}]"
+        payload = json.dumps(value.get("input", {}), ensure_ascii=False, sort_keys=True)
+        return f"[tool_use {name}]\n{payload}"
+    if item_type == "tool_result":
+        result = content_text(value.get("content"), include_tool_json=include_tool_json)
+        return f"[tool_result]\n{result}" if result else "[tool_result]"
+
+    for key in ("text", "content", "message", "output", "error"):
+        if key in value:
+            return content_text(value[key], include_tool_json=include_tool_json)
+    return ""
+
+
+def read_events(path: Path, *, include_tool_json: bool = True) -> list[ChatEvent]:
+    events: list[ChatEvent] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                events.append(ChatEvent(role="unknown", text=line.rstrip()))
+                continue
+
+            role = str(payload.get("role", "unknown"))
+            message = payload.get("message", {})
+            content = message.get("content") if isinstance(message, dict) else payload.get("content")
+            text = content_text(content, include_tool_json=include_tool_json).strip()
+            if text:
+                events.append(ChatEvent(role=role, text=text))
+    return events
+
+
+def extract_user_query(text: str) -> str:
+    text = re.sub(r"<manually_attached_skills>.*?</manually_attached_skills>", "", text, flags=re.S)
+    query = re.search(r"<user_query>\s*(.*?)\s*</user_query>", text, flags=re.S)
+    if query:
+        return query.group(1)
+    text = re.sub(r"<timestamp>.*?</timestamp>", "", text, flags=re.S)
+    text = re.sub(r"<[^>]+>", " ", text)
+    return text
+
+
+def title_for_events(events: list[ChatEvent], fallback: str) -> str:
+    prompt = first_prompt_for_events(events)
+    if not prompt:
+        return fallback
+    cleaned = re.sub(r"https?://[^\s)>\]]+", lambda match: urlparse(match.group(0)).netloc or "link", prompt)
+    words = re.findall(r"[\w#./:-]+", cleaned)
+    title = " ".join(words[:6]) or fallback
+    if len(title) > 80:
+        title = f"{title[:77].rstrip()}..."
+    return title
+
+
+def first_prompt_for_events(events: list[ChatEvent]) -> str:
+    first_user = next((event.text for event in events if event.role == "user"), "")
+    return " ".join(extract_user_query(first_user).split())
+
+
+def chat_from_path(path: Path) -> Chat:
+    events = read_events(path, include_tool_json=False)
+    chat_id = path.stem
+    title = title_for_events(events, fallback=chat_id)
+    prompt = first_prompt_for_events(events)
+    mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=LOCAL_TZ)
+    is_subagent = "subagents" in path.parts
+    citation = f"[{title}]({chat_id})" if not is_subagent else chat_id
+    return Chat(
+        id=chat_id,
+        path=path,
+        mtime=mtime,
+        line_count=len(events),
+        title=title,
+        prompt=prompt,
+        citation=citation,
+        is_subagent=is_subagent,
+    )
+
+
+def selected_chats(args: argparse.Namespace) -> list[Chat]:
+    root = transcript_root(args)
+    window = build_window(args)
+    chats = [
+        chat_from_path(path)
+        for path in iter_transcript_paths(root, args.include_subagents)
+        if in_window(path, window)
+    ]
+    return sorted(chats, key=lambda chat: chat.mtime, reverse=True)
+
+
+def resolve_chat_path(args: argparse.Namespace, chat_ref: str) -> Path:
+    maybe_path = Path(chat_ref).expanduser()
+    if maybe_path.exists():
+        return maybe_path.resolve()
+
+    root = transcript_root(args)
+    matches = [
+        path
+        for path in iter_transcript_paths(root, include_subagents=True)
+        if path.stem == chat_ref or path.stem.startswith(chat_ref)
+    ]
+    if not matches:
+        raise SystemExit(f"No transcript matched {chat_ref!r} under {root}")
+    if len(matches) > 1:
+        choices = "\n".join(str(path) for path in matches[:10])
+        raise SystemExit(f"Multiple transcripts matched {chat_ref!r}; use a longer id:\n{choices}")
+    return matches[0]
+
+
+def chat_to_dict(chat: Chat) -> dict[str, Any]:
+    return {
+        "id": chat.id,
+        "title": chat.title,
+        "prompt": chat.prompt,
+        "citation": chat.citation,
+        "updated_at": chat.mtime.isoformat(),
+        "messages": chat.line_count,
+        "path": str(chat.path),
+        "is_subagent": chat.is_subagent,
+    }
+
+
+def render_chat(chat: Chat, *, include_tool_json: bool) -> str:
+    events = read_events(chat.path, include_tool_json=include_tool_json)
+    parts = [
+        f"# {chat.title}",
+        "",
+        f"Chat ID: {chat.id}",
+        f"Updated: {chat.mtime.isoformat()}",
+        f"Citation: {chat.citation}",
+        f"Path: {chat.path}",
+        "",
+    ]
+    for index, event in enumerate(events, start=1):
+        parts.append(f"## {index}. {event.role}")
+        parts.append("")
+        parts.append(event.text)
+        parts.append("")
+    return "\n".join(parts).rstrip()
+
+
+def render_snippet(text: str, match: re.Match[str], context_chars: int) -> str:
+    start = max(0, match.start() - context_chars)
+    end = min(len(text), match.end() + context_chars)
+    snippet = text[start:end].replace("\n", " ")
+    prefix = "..." if start > 0 else ""
+    suffix = "..." if end < len(text) else ""
+    matched = text[match.start() : match.end()].replace("\n", " ")
+    snippet_start = match.start() - start
+    snippet_end = snippet_start + len(matched)
+    return f"{prefix}{snippet[:snippet_start]}<<{snippet[snippet_start:snippet_end]}>>{snippet[snippet_end:]}{suffix}"
+
+
+def command_list(args: argparse.Namespace) -> int:
+    chats = selected_chats(args)
+    if args.json:
+        print(json.dumps([chat_to_dict(chat) for chat in chats], indent=2))
+        return 0
+
+    window = build_window(args)
+    print(f"Cursor chats updated in {window.label}: {len(chats)}")
+    for chat in chats:
+        subagent = " subagent" if chat.is_subagent else ""
+        print(
+            f"{chat.mtime.strftime('%Y-%m-%d %H:%M:%S %Z')}  "
+            f"{chat.citation}  messages={chat.line_count}{subagent}"
+        )
+        print(f"  id: {chat.id}")
+        if chat.prompt:
+            print(f"  prompt: {chat.prompt}")
+    return 0
+
+
+def command_search(args: argparse.Namespace) -> int:
+    flags = 0 if args.case_sensitive else re.IGNORECASE
+    pattern = args.query if args.regex else re.escape(args.query)
+    regex = re.compile(pattern, flags)
+    results: list[dict[str, Any]] = []
+
+    for chat in selected_chats(args):
+        events = read_events(chat.path, include_tool_json=True)
+        haystack = "\n\n".join(f"{event.role}: {event.text}" for event in events)
+        hits = []
+        for match in regex.finditer(haystack):
+            hits.append(
+                {
+                    "snippet": render_snippet(haystack, match, args.context_chars),
+                    "start": match.start(),
+                }
+            )
+            if len(hits) >= args.per_chat_limit:
+                break
+        if hits:
+            results.append({"chat": chat_to_dict(chat), "hits": hits})
+            if len(results) >= args.limit:
+                break
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+        return 0
+
+    print(f"Search: {args.query!r}")
+    print(f"Chats with hits: {len(results)}")
+    for result in results:
+        chat = result["chat"]
+        print(f"\n{chat['updated_at']}  {chat['citation']}")
+        print(f"  id: {chat['id']}")
+        for index, hit in enumerate(result["hits"], start=1):
+            print(f"  hit {index}: {hit['snippet']}")
+    return 0
+
+
+def command_show(args: argparse.Namespace) -> int:
+    path = resolve_chat_path(args, args.chat)
+    chat = chat_from_path(path)
+    print(render_chat(chat, include_tool_json=args.include_tool_json))
+    return 0
+
+
+def add_window_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--state-window", action="store_true", help="Use pending_since_at/last_reviewed_through_at through last_started_at from the steward state file.")
+    parser.add_argument("--state-file", default=str(DEFAULT_STATE_FILE), help="Daily Jira Steward state file for --state-window.")
+    parser.add_argument("--date", help="Local day to inspect, as YYYY-MM-DD.")
+    parser.add_argument("--since", help="Inclusive local/ISO start timestamp with no end; use for from this date through now.")
+    parser.add_argument("--start", help="Inclusive local/ISO start timestamp.")
+    parser.add_argument("--end", help="Exclusive local/ISO end timestamp.")
+
+
+def add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--project-root", default=str(DEFAULT_PROJECT_ROOT), help="Workspace root used to infer Cursor's project transcript folder.")
+    parser.add_argument("--transcripts-root", help="Explicit agent-transcripts directory.")
+    parser.add_argument("--include-subagents", action="store_true", help="Include subagent transcripts. Parent chats are used by default.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="List chat transcripts updated in a date window.")
+    add_common_args(list_parser)
+    add_window_args(list_parser)
+    list_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    list_parser.set_defaults(func=command_list)
+
+    search_parser = subparsers.add_parser("search", help="Search transcript text in a date window.")
+    add_common_args(search_parser)
+    add_window_args(search_parser)
+    search_parser.add_argument("query", help="Search string or regex pattern.")
+    search_parser.add_argument("--regex", action="store_true", help="Treat query as a regular expression.")
+    search_parser.add_argument("--case-sensitive", action="store_true", help="Use case-sensitive matching.")
+    search_parser.add_argument("--context-chars", type=int, default=160, help="Characters of context around each hit.")
+    search_parser.add_argument("--limit", type=int, default=20, help="Maximum chats to return.")
+    search_parser.add_argument("--per-chat-limit", type=int, default=5, help="Maximum hits per chat.")
+    search_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    search_parser.set_defaults(func=command_search)
+
+    show_parser = subparsers.add_parser("show", help="Render one full chat by id prefix or path.")
+    add_common_args(show_parser)
+    show_parser.add_argument("chat", help="Chat id, id prefix, or transcript path.")
+    show_parser.add_argument("--include-tool-json", action="store_true", help="Include full tool call inputs and tool result content.")
+    show_parser.set_defaults(func=command_show)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.cursor/skills/daily-jira-steward/templates.md
+++ b/.cursor/skills/daily-jira-steward/templates.md
@@ -34,6 +34,15 @@ Last updated: YYYY-MM-DD
 - Docs: ...
 ```
 
+Guidelines:
+
+- `Now` reflects current focus, goal, status, blockers, and 3-5 high-signal links.
+- `Next` is ordered, actionable, and uses readable `PR #N: title` / `ROS-N: title` style.
+- `Backlog` holds tickets or themes not actively being worked this week.
+- `Done Recently` rotates forward; remove bullets that are no longer useful for standups or manager visibility.
+- Prefer markdown links over bare URLs. Use full remote URLs, not relative paths, because Google Docs readers need links that work outside the local checkout.
+- Do not include approval-gated Jira or GitHub writes that are still pending unless they are already part of the user's committed plan.
+
 ## Daily Report
 
 Use this structure when writing the report file:
@@ -121,3 +130,5 @@ Use only these columns:
 | JIRA-1 | Jira transition for `ROS-123: Add status reconciliation` | Move from `In Progress` to `In Review`. Evidence: `PR #456: Add reconciliation` is open. | Pending |
 | GH-1 | GitHub PR update for `PR #456: Add reconciliation` | Replace `[n/a]` with `ROS-123: Add status reconciliation`. Evidence: PR implements tracked Jira work. | Pending |
 ```
+
+For new ticket creation, start the `Write` cell with `Jira create: [ticket summary]`. For existing tickets and PRs, include both the target identifier and readable title in the `Write` cell.

--- a/.cursor/skills/daily-jira-steward/templates.md
+++ b/.cursor/skills/daily-jira-steward/templates.md
@@ -1,0 +1,123 @@
+# Daily Jira Steward Templates
+
+Use these templates when writing or refreshing the steward artifacts.
+
+## `me.md`
+
+Every link in `me.md` must work for someone reading the Google Doc. Never use local filesystem paths, `file://` URLs, `localhost` URLs, or machine-specific links. If an artifact only exists locally, describe it without linking until it has a shareable remote URL.
+
+```markdown
+# Josh Goon Work Visibility
+
+Last updated: YYYY-MM-DD
+
+## Now
+- **Focus:** ...
+- **Goal:** ...
+- **Status:** ...
+- **Needs attention:** ...
+- **Links:** [latest daily report](https://github.rbx.com/jgoon/daily-reports/blob/main/reports/YYYY-MM-DD.md), ...
+
+## Next
+- [concrete next actions with PR/Jira links]
+
+## Backlog
+- [lower-priority or stale follow-ups with links]
+
+## Done Recently
+- [3-6 bullets for work completed or materially advanced in the last ~2 weeks; drop items older than that]
+
+## Useful Links
+- Daily reports: [YYYY-MM-DD](https://github.rbx.com/jgoon/daily-reports/blob/main/reports/YYYY-MM-DD.md), ...
+- Jira: [active ROS work](...)
+- GitHub: [ROS PRs by Josh](...), [ros-infra PRs by Josh](...)
+- Docs: ...
+```
+
+## Daily Report
+
+Use this structure when writing the report file:
+
+```markdown
+## Daily Work Report
+
+Window: [start time] to [end time]
+Report saved at: [repo path]
+
+## Sources Checked
+
+- [source and scope]
+
+## Work Log
+
+- [workstream or project]: [what the user did, evidence or artifacts, outcome or progress, blockers or next step if visible]
+
+## Slack Evidence
+
+- Broad search: [time window, query shape, high-signal hits, and important misses]
+- Targeted search: [Jira keys, PRs, workstream terms searched, high-signal hits, and important misses]
+- Threads expanded: [channel/thread context, what decision/blocker/coordination was found, or rate-limit skip]
+
+## Artifact Summary
+
+- PR: [PR number and title, created/merged/reviewed/materially updated, why it mattered]
+- Jira: [ticket key and title, work performed or status observed]
+- Doc/Chat/Other: [artifact title or source, work performed or decision made]
+
+## Intentional Omissions / No Action
+
+- [reviewed evidence intentionally left out of the work log, `me.md`, or proposed updates, with the reason]
+
+## Pending Approval
+
+| Change ID                 | Write                                            | Details                                          | Status                                             |
+| ------------------------- | ------------------------------------------------ | ------------------------------------------------ | -------------------------------------------------- |
+| [prior pending change ID] | [system, action, target, and readable title]     | [specific proposed write plus supporting evidence] | [Pending, Approved, Applied, Skipped, or Rejected] |
+
+## GitHub Activity
+
+- [PR created, merged, reviewed, or materially updated, always including PR number and title]
+
+## Current Jira Triage
+
+- [ticket key and title, observed state, proposed action or reason no action is needed]
+
+## Stale Ticket Callouts
+
+- [ticket key and title, age since last update, status, why it may need attention, lightest useful next step]
+
+## Proposed Jira Updates
+
+- Create: [ticket summary and reason]
+- Update: [ticket key and title, comment or field change, reason]
+- Transition: [ticket key and title, from state to state, evidence]
+- Skip: [work item, reason no Jira change is needed]
+
+## Proposed GitHub PR Updates
+
+- Update: [PR number and title, body/title/comment change, reason]
+
+## Questions
+
+- [Only include blockers that require user judgment]
+```
+
+If there is no tracker or PR change to make, still write the full daily report and say external tracking appears aligned.
+
+## Pending Draft
+
+Every pending draft must include a proposed-changes table before detailed notes. Keep one row per write action so it can be converted directly into answers UI options.
+
+Use only these columns:
+
+- `Change ID`: stable identifier such as `JIRA-1` or `GH-1`.
+- `Write`: system, action, target, and readable title or summary.
+- `Details`: proposed change plus supporting evidence.
+- `Status`: `Pending`, `Approved`, `Applied`, `Skipped`, or `Rejected`, with a short reason when helpful.
+
+```markdown
+| Change ID | Write | Details | Status |
+| --------- | ----- | ------- | ------ |
+| JIRA-1 | Jira transition for `ROS-123: Add status reconciliation` | Move from `In Progress` to `In Review`. Evidence: `PR #456: Add reconciliation` is open. | Pending |
+| GH-1 | GitHub PR update for `PR #456: Add reconciliation` | Replace `[n/a]` with `ROS-123: Add status reconciliation`. Evidence: PR implements tracked Jira work. | Pending |
+```


### PR DESCRIPTION
## Summary
- Rework the Daily Jira Steward skill around a clear checkpoint workflow: source evidence, publish owned artifacts, draft pending updates, then approval-gate external writes.
- Add a Cursor chat helper for listing/searching/showing transcripts by checkpoint window.
- Move artifact templates into a separate `templates.md` reference file.

## Test plan
- Ran `python3 -m py_compile ~/.cursor/skills/daily-jira-steward/scripts/cursor-chat-search.py`.
- Ran sample `list --state-window` checks while developing the helper.
- Checked Cursor lints for the edited skill and template files.

Made with [Cursor](https://cursor.com)